### PR TITLE
Add requirement for manufacturer data in the advertised packets on the KKM ScanFilter.

### DIFF
--- a/kbeaconlib2/src/main/java/com/kkmcn/kbeaconlib2/KBeaconsMgr.java
+++ b/kbeaconlib2/src/main/java/com/kkmcn/kbeaconlib2/KBeaconsMgr.java
@@ -327,7 +327,7 @@ public class KBeaconsMgr {
                     iBeaconFilter);
 
             ScanFilter.Builder filter4 = new ScanFilter.Builder().setManufacturerData(KBUtility.KKM_MANUFACTURE_ID,
-                    null);
+                    new byte[0]);
             filterList.add(filter1.build());
             filterList.add(filter2.build());
             filterList.add(filter3.build());


### PR DESCRIPTION
With a `null` value in the scan filter, some Samsung devices will terminate the scan once the screen goes off.

This is the log message that is printed just after the screen goes off

`**[GSIM LOG]: gsimLogHandler, msg: MESSAGE_SCAN_STOP, appName: com.packagename.other, scannerId: 11, reportDelayMillis=0**`